### PR TITLE
Fix module description

### DIFF
--- a/src/Data/Digest/CRC32C.hs
+++ b/src/Data/Digest/CRC32C.hs
@@ -5,8 +5,7 @@
 -- Stability   : stable
 -- Portability : non-portable (GHC extensions)
 --
-
--- | Implementation of the CRC32C checksum algorithm.
+-- Implementation of the CRC32C checksum algorithm.
 --
 -- The current implementation is in "pure" Haskell, thus does not take advantage
 -- of hardware implementations available on several CPU types. It's performance


### PR DESCRIPTION
Hello,

This fix of module description is necessary for building haddock documents. The building process fails with the error below without it:

```
Running Haddock on library for snappy-framing-0.1.1..

src/Data/Digest/CRC32C.hs:9:1: error:
    parse error on input ‘-- | Implementation of the CRC32C checksum algorithm.
--
-- The current implementation is in "pure" Haskell, thus does not take advantage
-- of hardware implementations available on several CPU types. It's performance
-- (throughput) is therefore possibly insufficient for certain classes of
-- applications.
--
-- Attribution: it is believed that the code is, at least partly, based on an
-- implementation by Edward Kmett, which has since vanished from the internet.
--’
  |
9 | -- | Implementation of the CRC32C checksum algorithm.
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```